### PR TITLE
fix ballot locator link in booth success page

### DIFF
--- a/avBooth/success-screen-directive/success-screen-directive.html
+++ b/avBooth/success-screen-directive/success-screen-directive.html
@@ -47,7 +47,7 @@
   <div class="container">
     <div class="padded">
       <p ng-i18next>
-        [html:i18next]({ballotHash: stateData.ballotHash, ballotLocatorUrl: "#/election/" +election.id + "/public/ballot-locator"})avBooth.successBallotHash
+        [html:i18next]({ballotHash: stateData.ballotHash, ballotLocatorUrl: "/election/" +election.id + "/public/ballot-locator"})avBooth.successBallotHash
       </p>
 <!--      <p ng-i18next>avBooth.relatedLinksText</p>
       <ul>


### PR DESCRIPTION
fix ballot locator link in booth success page, it was using the old link format that is not working anymor

Steps to reproduce the bug:
1. vote (using demo voting booth for example)
2. in the last step, click on the link to find your ballot locator
3. it doesn't work

How it should work instead:
1. vote (using demo voting booth for example)
2. in the last step, click on the link to find your ballot locator
3. page would load the ballot locator