### PR TITLE
blank vote should not be a show-stopper if allowed

### DIFF
--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
@@ -112,6 +112,11 @@ angular.module('avBooth')
                       (
                         checkerTypeFlag === "show-stoppers" && 
                         question.extra_options.invalid_vote_policy !== 'not-allowed'
+                      ) ||
+                      (
+                        checkerTypeFlag === "show-stoppers" &&
+                        question.extra_options.invalid_vote_policy === 'not-allowed' &&
+                        question.min === 0
                       )
                     );
                   },


### PR DESCRIPTION
If a question has blank votes allowed (question.min is 0), but question.extra_options.invalid_vote_policy is ser 'not-allowed' , currently blank votes are deemed incorrectly as invalid.

This PR fixes this. Now in this case the blank-votes warning shows, but not as a show-stopper.