### PR TITLE
fixing demo booth for disabled election chooser

### DIFF
--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
@@ -119,7 +119,7 @@ angular.module('avBooth')
 
             // if election chooser is disabled and can vote, then go to the first
             // election in which it can vote
-            if (disableElectionChooser && scope.canVote) {
+            if (disableElectionChooser && scope.canVote && !scope.isDemo) {
                 var credentials = getElectionCredentials();
                 var orderedElectionIds = scope.childrenElectionInfo.natural_order;
                 for (var i = 0; i < orderedElectionIds.length; i++) {


### PR DESCRIPTION
Election chooser will be shown always because we are not using credentials in the demo booth so we don't know which election should be shown to the voter.