### PR TITLE
Fix election description in parent-elections

### DIFF
--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
@@ -128,7 +128,7 @@
         <div class="election-description">
           <p
             class="election-description"
-            ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description)) | addTargetBlank"
+            ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description) || '') | addTargetBlank"
           ></p>
         </div>
         <div

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
@@ -94,10 +94,14 @@
       <div class="hidden unfixed-top-height"></div>
       <h1>
         {{
-          parentElection.presentation.extra_options.public_title ||
-          parentElection.title ||
-          election.presentation.extra_options.public_title ||
-          election.title
+          parentElection && (
+            parentElection.presentation.extra_options.public_title ||
+            parentElection.title
+          ) ||
+          !parentElection && (
+            election.presentation.extra_options.public_title ||
+            election.title
+          )
         }}
       </h1>
     </div>
@@ -124,7 +128,7 @@
         <div class="election-description">
           <p
             class="election-description"
-            ng-bind-html="(parentElection.description || election.description) | addTargetBlank"
+            ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description)) | addTargetBlank"
           ></p>
         </div>
         <div

--- a/avBooth/start-screen-directive/start-screen-directive.html
+++ b/avBooth/start-screen-directive/start-screen-directive.html
@@ -94,13 +94,17 @@
       <div class="hidden unfixed-top-height"></div>
       <h1>
         {{
-          parentElection.presentation.extra_options.public_title ||
-          parentElection.title ||
-          election.presentation.extra_options.public_title ||
-          election.title
+          !!parentElection && (
+            parentElection.presentation.extra_options.public_title ||
+            parentElection.title
+          ) ||
+          !parentElection && (
+            election.presentation.extra_options.public_title ||
+            election.title
+          )
         }}
       </h1>
-      <p class="description" ng-bind-html="(parentElection.description || election.description) | addTargetBlank"></p>
+      <p class="description" ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description)) | addTargetBlank"></p>
     </div>
   </div>
 </div>

--- a/avBooth/start-screen-directive/start-screen-directive.html
+++ b/avBooth/start-screen-directive/start-screen-directive.html
@@ -104,7 +104,7 @@
           )
         }}
       </h1>
-      <p class="description" ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description)) | addTargetBlank"></p>
+      <p class="description" ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description) || '') | addTargetBlank"></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If election description was empty in the parent election, the election description of children election would appear and that should not happen.