### PR TITLE
Fix log-out button in success screen

### DIFF
--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
@@ -177,7 +177,7 @@
       >
         <a
           tabindex="0"
-          ng-click="logoutAndRedirect()"
+          ng-click="logoutAndRedirect(showSkippedElections || (!canVote && hasVoted))"
           target="_top"
           class="logout-btn btn btn-default" ng-i18next>
           avBooth.logout


### PR DESCRIPTION
Log out button in success page (when the voter has finished voting) for parent-children elections should redirect to `election.presentation.extra_options.success_screen__redirect__url` if it that extra option is set. Before, it was ignoring this setting and always redirecting to login after clicking the log-out button.