### PR TITLE
fix redirect to login button

### DIFF
--- a/avBooth/success-screen-directive/success-screen-directive.html
+++ b/avBooth/success-screen-directive/success-screen-directive.html
@@ -102,7 +102,7 @@
           <span>
             <a
               tabindex="0"
-              ng-click="redirectToLogin()"
+              ng-click="redirectToLogin(true)"
               class="btn btn-primary btn-login">
               {{ election.presentation.extra_options.success_screen__redirect_to_login__text }}
             </a>


### PR DESCRIPTION
When setting not only `success_screen__redirect__url`but also the `success_screen__redirect_to_login`, that activates another button redirect-to-login button different to the default one, to show a specific text that is provided using the `success_screen__redirect_to_login__text` option. In this secondary button, the `success_screen__redirect__url` extra option was being ignored even if provided. This PR fixes that, so that it won't be ignored anymore, and instead, it'll be used for redirecting to the given login url (if provided) in redirect-to-login button in election success screen. 