### PR TITLE
success-screen: Fixing success_screen__hide_ballot_tracker and success_screen__hide_qr_code options

### DIFF
--- a/avBooth/success-screen-directive/success-screen-directive.html
+++ b/avBooth/success-screen-directive/success-screen-directive.html
@@ -115,7 +115,7 @@
 
           &nbsp;
           <span
-            ng-if="!election.presentation.extra_options.success_screen__hide_ballot_tracker && election.presentation.extra_options.success_screen__hide_qr_code !== true">
+            ng-if="election.presentation.extra_options.success_screen__hide_qr_code !== true">
             <span ng-i18next>
               avBooth.successBallotQrCode
             </span>
@@ -130,7 +130,7 @@
             class="btn btn-primary btn-login"
             tabindex="0"
             ng-click="downloadBallotTicket()"
-            ng-if="!election.presentation.extra_options.success_screen__hide_ballot_tracker && election.presentation.extra_options.success_screen__hide_download_ballot_ticket !== true"
+            ng-if="election.presentation.extra_options.success_screen__hide_download_ballot_ticket !== true"
             target="_blank"
             ng-i18next>
             avBooth.downloadBallotTicket

--- a/avBooth/success-screen-directive/success-screen-directive.js
+++ b/avBooth/success-screen-directive/success-screen-directive.js
@@ -133,6 +133,26 @@ angular.module('avBooth')
 
         function download(images) 
         {
+          var ballotTrackerRow = (
+            scope.election.presentation.extra_options &&
+            scope.election.presentation.extra_options.success_screen__hide_ballot_tracker
+          ) ?
+          {} :
+          {
+            columns: [
+              {
+                text: $i18next('avBooth.ballotTicket.tracker'),
+                style: 'cell',
+                width: '40%'
+              },
+              {
+                text: scope.stateData.ballotHash.substr(0, 32) + ' ' + scope.stateData.ballotHash.substr(32, 32),
+                style: 'cell',
+                width: '*'
+              }
+            ]
+          };
+
           var docDefinition = {
             info: {
               title: scope.pdf.fileName,
@@ -159,20 +179,7 @@ angular.module('avBooth')
                 text: scope.election.presentation.extra_options && scope.election.presentation.extra_options.success_screen__ballot_ticket__h4 || $i18next('avBooth.ballotTicket.h4'),
                 style: 'h4'
               },
-              {
-                columns: [
-                  {
-                    text: $i18next('avBooth.ballotTicket.tracker'),
-                    style: 'cell',
-                    width: '40%'
-                  },
-                  {
-                    text: scope.stateData.ballotHash.substr(0, 32) + ' ' + scope.stateData.ballotHash.substr(32, 32),
-                    style: 'cell',
-                    width: '*'
-                  }
-                ]
-              },
+              ballotTrackerRow,
               {
                 columns: [
                   {

--- a/avBooth/success-screen-directive/success-screen-directive.js
+++ b/avBooth/success-screen-directive/success-screen-directive.js
@@ -395,7 +395,7 @@ angular.module('avBooth')
       function generateQrCode() {
         if (
           !scope.election.presentation.extra_options || 
-          !scope.election.presentation.extra_options.success_screen__hide_ballot_tracker
+          !scope.election.presentation.extra_options.success_screen__hide_qr_code
         ) {
           var typeNumber = 0;
           var errorCorrectionLevel = 'L';


### PR DESCRIPTION
The activation of the `election.presentation.extra_options.success_screen__hide_ballot_tracker` setting should not hide the Download Ballot ticket button in the voting booth success-screen, but it was doing that so we are fixing it. 
This setting, when enabled, it also hiding the QR Code both in the success screen and within the PDF ballot ticket, so we are fixing that too. Finally, when enabled, this setting should (but it was not) hide the ballot tracker line in the PDF ballot ticket.